### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -67,12 +67,21 @@
       {
         "url": "https://identity.pagerduty.com/oauth/.*",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "app_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       },
       {
         "url": "https://api.pagerduty.com/.*",
         "methods": ["GET", "POST", "PUT"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {}
       }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -69,7 +69,7 @@
         "methods": ["POST"],
         "timeout": 20,
         "settingsInjection": {
-          "app_id": {
+          "client_id": {
             "body": ["client_id"]
           },
           "client_secret": {


### PR DESCRIPTION
This pull request updates the `manifest.json` configuration to improve how sensitive settings are injected into PagerDuty API requests. The main change is the introduction of a new `settingsInjection` field for the PagerDuty OAuth endpoint, which specifies how the `app_id` and `client_secret` settings should be mapped into the request body.

Configuration improvements for PagerDuty integration:

* Added a `settingsInjection` field to the PagerDuty OAuth endpoint, mapping `app_id` to the `client_id` field and `client_secret` to the `client_secret` field in the request body.
* Added an empty `settingsInjection` field to the PagerDuty API endpoint for future extensibility.